### PR TITLE
added the ability to retrive the value of mount_ip from /etc/swift/fs.co...

### DIFF
--- a/bin/gluster-swift-gen-builders
+++ b/bin/gluster-swift-gen-builders
@@ -7,12 +7,23 @@ declare -A port=(["account.builder"]=6012 ["container.builder"]=6011 \
 
 builder_files="account.builder container.builder object.builder"
 
+mount_ip=`grep -i -P '^\s*mount_ip.+$' /etc/swift/fs.conf|cut -d \= -f 2|awk '{print $1}'`
+
+if [ -z $mount_ip  ]; then
+    mount_ip='127.0.0.1'
+else
+    echo $mount_ip |grep -P '\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}'
+    if [ "$?" -gt 0 ]; then
+        mount_ip=`python -c "import socket; print socket.gethostbyname(\"$mount_ip\")"`
+    fi
+fi
+
 function create {
     swift-ring-builder $1 create 1 1 1 >> /tmp/out
 }
 
 function add {
-    swift-ring-builder $1 add z$2-127.0.0.1:$3/$4_ 100.0
+    swift-ring-builder $1 add z$2-$3:$4/$5_ 100.0
 }
 
 function rebalance {
@@ -39,7 +50,7 @@ do
     zone=1
     for volname in $@
     do
-        add $builder_file $zone ${port[$builder_file]} $volname
+        add $builder_file $zone $mount_ip ${port[$builder_file]} $volname
         zone=$(expr $zone + 1)
     done
 


### PR DESCRIPTION
...nf to gluster-swift-gen-builders

this version of gluster-swift-gen-builders can get the value of mount_ip from /etc/swift/fs.conf then it detects if its a host name or IP if its a host name it resolves it because swift-ring-builder add fails if you use a host name.
The python socket.gethostbyname method is being used to resolve because even if the hostname is only in the /etc/hosts file, where by comparison the "host" command can only resolve names in a DNS and ignores the /etc/hosts file.
