### PR TITLE
Gluster Swift workaround file level WORM

### DIFF
--- a/gluster/swift/common/fs_utils.py
+++ b/gluster/swift/common/fs_utils.py
@@ -314,6 +314,23 @@ def do_fadvise64(fd, offset, length):
     _posix_fadvise(fd, ctypes.c_uint64(offset),
                    ctypes.c_uint64(length), 4)
 
+def do_removewritepermissions(path):
+    """Remove write permissions from this path, while keeping all other permissions intact.
+
+    Params:
+        path:  The path whose permissions to alter.
+    """
+    NO_USER_WRITING = ~stat.S_IWUSR
+    NO_GROUP_WRITING = ~stat.S_IWGRP
+    NO_OTHER_WRITING = ~stat.S_IWOTH
+    NO_WRITING = NO_USER_WRITING & NO_GROUP_WRITING & NO_OTHER_WRITING
+
+    try:
+        current_permissions = stat.S_IMODE(os.lstat(path).st_mode)
+        os.chmod(path, current_permissions & NO_WRITING)
+    except OSError as err:
+        raise GlusterFileSystemOSError(
+            err.errno, '%s, os.chmod("%s")' % (err.strerror, path))
 
 def do_lseek(fd, pos, how):
     try:


### PR DESCRIPTION
Gluster Swift workaround that fixes bug (https://bugzilla.redhat.com/show_bug.cgi?id=1480653)

What this does:
1 - When finalizing put, remove write permissions to trigger worm retention period
3 - When creating a temp file, check if the destination file exists and if the access time stat attribute is greater than now then raise an error so the file won't be overwritten.